### PR TITLE
hotfix for missing certificate #13

### DIFF
--- a/src/classes/Client.js
+++ b/src/classes/Client.js
@@ -564,7 +564,7 @@ var Client = utils.class_('Client', {
       if (!err)
         client._info = info;
 
-      if (!err && authenticate.cert) {
+      if (authenticate && !err && authenticate.cert) {
         client.authorizeCertificate(authenticate.password, function (err) {
           if (err && err._statusCode !== 400) {
             console.error('failed to authorize certificate');


### PR DESCRIPTION
There were more options to create hotfix,
```
constructor: function (host, authenticate = {key: null, cert: null}) {
```
 regarding to rest of implementation I'v chosen that one commited
